### PR TITLE
【依頼】フッターナビゲーションの「サイトマップ」の削除に関するコードレビュー

### DIFF
--- a/Q&A.html
+++ b/Q&A.html
@@ -339,7 +339,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Webページ制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/css-reference.html
+++ b/css-reference.html
@@ -277,7 +277,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Webページ制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/glossary.html
+++ b/glossary.html
@@ -404,7 +404,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Webページ制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/html-reference.html
+++ b/html-reference.html
@@ -651,7 +651,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Webページ制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/index.html
+++ b/index.html
@@ -49,7 +49,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Webページ制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/javascript-reference.html
+++ b/javascript-reference.html
@@ -702,7 +702,6 @@
   <footer class="site-footer">
     <div class="footer-copy">&copy;Web制作ガイド</div>
     <ul class="footer-nav-list">
-      <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
       <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
     </ul>

--- a/process.html
+++ b/process.html
@@ -292,7 +292,6 @@
     <footer class="site-footer">
         <div class="footer-copy">&copy;Webページ制作ガイド</div>
         <ul class="footer-nav-list">
-            <li class="footer-nav-item"><a href="#" class="footer-nav-link">サイトマップ</a></li>
             <li class="footer-nav-item"><a href="#" class="footer-nav-link">プライバシーポリシー</a></li>
             <li class="footer-nav-item"><a href="#" class="footer-nav-link">利用規約</a></li>
         </ul>


### PR DESCRIPTION
# What
- 環境構築のページを除くページのフッターナビゲーションの「サイトマップ」のリンクを削除しました。

# Why
- サイトマップのリンク及びページは作成しなくてよいという方針のため。

## 更新したファイルと内容
- フッターナビゲーションの「サイトマップ」のリンクを削除
    - index.html
    - proccess.html
    - glossary.htm
    - html-reference.html
    - css-reference.html
    - javascript-reference.html
    - Q&A.html
- 更新後のヘッダーナビゲーションのスクリーンショット
- URL：https://gyazo.com/f6801fd705b131de6e6867556998c414

## テスト
- Chromeで変更内容を正しく反映できていることを確認しました。

## 確認依頼
- 変更したページのレイアウトやスタイルに関するフィードバックをお願いします。
- 全体的なコードの品質や可読性についてレビューをお願いします。
- 特に問題がなければLGTMをプルリクエストのコメントにてお知らせください。